### PR TITLE
Add icons to start-menu shortcuts

### DIFF
--- a/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
+++ b/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
@@ -18,9 +18,9 @@ function createShortcuts()
     }
 
     var cmdLocation = installer.value("TargetDir") + "\\msys2_shell.cmd";
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 32-bit.lnk", "-mingw32");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 64-bit.lnk", "-mingw64");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MSYS.lnk", "-msys");
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 32-bit.lnk", "-mingw32", "iconPath=@TargetDir@/mingw32.exe");
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW 64-bit.lnk", "-mingw64", "iconPath=@TargetDir@/mingw64.exe");
+    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MSYS.lnk", "-msys", "iconPath=@TargetDir@/msys2.exe");
 
     if ("@BITNESS@bit" === "32bit") {
         component.addOperation( "Execute",


### PR DESCRIPTION
This PR adds icons to the start-menu entries.

I followed examples from https://doc.qt.io/qtinstallerframework/qt-installer-framework-startmenu-example.html#adding-entries-to-start-menu and https://stackoverflow.com/questions/46040537/qt-installer-framework-create-shortcut-with-argument and build and tested the x64 installer. 

old
![msys2-old](https://user-images.githubusercontent.com/8088070/72297985-64401080-365d-11ea-9a82-63571cf2a111.png)
new
![msys2-new](https://user-images.githubusercontent.com/8088070/72297988-65713d80-365d-11ea-8a93-7b95ef2c9663.png)
