### PR TITLE
Remove all modify functionality, rename binary

### DIFF
--- a/qt-ifw/config/config.xml
+++ b/qt-ifw/config/config.xml
@@ -11,7 +11,7 @@
     <InstallerApplicationIcon>../../msys2</InstallerApplicationIcon>
     <InstallerWindowIcon>../../msys2</InstallerWindowIcon>
     <InstallActionColumnVisible>false</InstallActionColumnVisible>
-    <MaintenanceToolName>Uninstall_MSYS2</MaintenanceToolName>
+    <MaintenanceToolName>Uninstall</MaintenanceToolName>
     <SupportsModify>false</SupportsModify>
     <RepositorySettingsPageVisible>false</RepositorySettingsPageVisible>
     <SaveDefaultRepositories>false</SaveDefaultRepositories>

--- a/qt-ifw/config/config.xml
+++ b/qt-ifw/config/config.xml
@@ -4,9 +4,15 @@
     <Version>@VERSION@</Version>
     <Title>MSYS2 @BITNESS@bit</Title>
     <Publisher>The MSYS2 Developers</Publisher>
+    <ControlScript>control.js</ControlScript>
     <StartMenuDir>MSYS2 @BITNESS@bit</StartMenuDir>
     <RunProgram>@TargetDir@/msys2_shell.cmd</RunProgram>
     <RunProgramArguments></RunProgramArguments>
     <InstallerApplicationIcon>../../msys2</InstallerApplicationIcon>
     <InstallerWindowIcon>../../msys2</InstallerWindowIcon>
+    <InstallActionColumnVisible>false</InstallActionColumnVisible>
+    <MaintenanceToolName>Uninstall_MSYS2</MaintenanceToolName>
+    <SupportsModify>false</SupportsModify>
+    <RepositorySettingsPageVisible>false</RepositorySettingsPageVisible>
+    <SaveDefaultRepositories>false</SaveDefaultRepositories>
 </Installer>

--- a/qt-ifw/config/control.js
+++ b/qt-ifw/config/control.js
@@ -1,0 +1,15 @@
+function Controller()
+{
+}
+
+Controller.prototype.IntroductionPageCallback = function()
+{
+  var widget = gui.currentPageWidget();
+  radioNames = ["PackageManagerRadioButton", "UpdaterRadioButton"];
+  for (name of radioNames) {
+    var el = gui.findChild(widget, name);
+    if (el != null) {
+      el.hide();
+    }
+  }
+}


### PR DESCRIPTION
This PR removes the maintenance tool's misleading ability to reconfigure/update the installed components, restricting the features offered to the only one actually functional: Uninstalling MSYS2.

- The maintenance tool is now installed as `Uninstall.exe`, to make its purpose clearer:
    ![msys2-install-rename](https://user-images.githubusercontent.com/538020/116400408-ff7bdb80-a7f7-11eb-80be-5d136c9a7226.png)
(Screenshot is out of date.)

- The 'Modify' button is disabled in the Windows Settings 'Apps' list:
    ![msys2-install-winsettings](https://user-images.githubusercontent.com/538020/116400435-06a2e980-a7f8-11eb-9d36-ba556ab56d13.png)

- The Add/Remove and Modify choices are hidden on the Introduction page, leaving 'Remove all components' as the only available selection:

    ![msys2-install-choices](https://user-images.githubusercontent.com/538020/116400448-0c003400-a7f8-11eb-9297-0dba250afdf5.png)


- (Even though it's no longer accessible, the Repository configuration tab of the Settings dialog is also removed)