### PR TITLE
control.js: Use const variables

### DIFF
--- a/qt-ifw/config/control.js
+++ b/qt-ifw/config/control.js
@@ -4,10 +4,10 @@ function Controller()
 
 Controller.prototype.IntroductionPageCallback = function()
 {
-  var widget = gui.currentPageWidget();
-  radioNames = ["PackageManagerRadioButton", "UpdaterRadioButton"];
-  for (name of radioNames) {
-    var el = gui.findChild(widget, name);
+  const widget = gui.currentPageWidget();
+  const radioNames = ["PackageManagerRadioButton", "UpdaterRadioButton"];
+  for (const name of radioNames) {
+    const el = gui.findChild(widget, name);
     if (el != null) {
       el.hide();
     }


### PR DESCRIPTION
It's neurotic, I know, but after it was merged I noticed that the JS code in my PR #25 was missing a couple of `var`s on its variable declarations.

It's perfectly _legal_ to do that in JavaScript, the code works fine, but... it would've bugged me.

So, as penance, this PR replaces all of the `var`s — missing and present — in the code with `const`s, since QJSEngine is ES6-compliant<sup>1</sup> and none of the variables ever actually get modified before falling out of scope. It's cleaner, more modern code that I don't have to be vaguely ashamed to have my name on. :wink: 

#### Notes
1. (It would have to be, I already used a `for(... of ...)` loop.)