### PR TITLE
shortcuts: start launcher and rename

### DIFF
--- a/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
+++ b/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
@@ -17,12 +17,11 @@ function createShortcuts()
         return;
     }
 
-    var cmdLocation = installer.value("TargetDir") + "\\msys2_shell.cmd";
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW x86.lnk", "-mingw32", "iconPath=@TargetDir@/mingw32.exe");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW x64.lnk", "-mingw64", "iconPath=@TargetDir@/mingw64.exe");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW UCRT x64.lnk", "-ucrt64", "iconPath=@TargetDir@/ucrt64.exe");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MinGW Clang x64.lnk", "-clang64", "iconPath=@TargetDir@/clang64.exe");
-    component.addOperation("CreateShortcut", cmdLocation, "@StartMenuDir@/MSYS2 MSYS.lnk", "-msys", "iconPath=@TargetDir@/msys2.exe");
+    component.addOperation("CreateShortcut", "@TargetDir@/mingw32.exe", "@StartMenuDir@/MSYS2 MINGW32.lnk", "iconPath=@TargetDir@/mingw32.exe");
+    component.addOperation("CreateShortcut", "@TargetDir@/mingw64.exe", "@StartMenuDir@/MSYS2 MINGW64.lnk", "iconPath=@TargetDir@/mingw64.exe");
+    component.addOperation("CreateShortcut", "@TargetDir@/ucrt64.exe", "@StartMenuDir@/MSYS2 UCRT64.lnk", "iconPath=@TargetDir@/ucrt64.exe");
+    component.addOperation("CreateShortcut", "@TargetDir@/clang64.exe", "@StartMenuDir@/MSYS2 CLANG64.lnk", "iconPath=@TargetDir@/clang64.exe");
+    component.addOperation("CreateShortcut", "@TargetDir@/msys2.exe", "@StartMenuDir@/MSYS2 MSYS.lnk", "iconPath=@TargetDir@/msys2.exe");
 
     if ("@BITNESS@bit" === "32bit") {
         component.addOperation( "Execute",


### PR DESCRIPTION
Instead of calling msys2_shell.cmd call the respective launchers.
This unifies the way MSYS2 is started for most users and allows them
to set launch variables in the launcher .ini files.

While at it also rename the shortcuts to reference the environment names
instead of describing the environment. Not everyone might care or know
what these mean, so just unify them with the MSYSTEM env var which is
shown when starting bash right after.

Fixes #24