### PR TITLE
Remove 32bit support and any mention of 64bit

### DIFF
--- a/make-msys2-installer
+++ b/make-msys2-installer
@@ -11,16 +11,11 @@ _filename=msys2-${_arch}-${_date}.exe
 _filename2=msys2-base-${_arch}-${_date}.tar.xz
 _filename3=msys2-base-${_arch}-${_date}.sfx.exe
 _log=/tmp/installer-${_arch}-${_date}.log
-if [ "${_arch}" = "x86_64" ]; then
-  _bitness=64
-else
-  _bitness=32
-fi
-_archivegen=/mingw${_bitness}/bin/archivegen.exe
-_binarycreator=/mingw${_bitness}/bin/binarycreator.exe
-_installerbase=/mingw${_bitness}/bin/installerbase.exe
+_archivegen=/mingw64/bin/archivegen.exe
+_binarycreator=/mingw64/bin/binarycreator.exe
+_installerbase=/mingw64/bin/installerbase.exe
 _newmsysbase=/tmp/newmsys
-_newmsys=${_newmsysbase}/msys"${_bitness}"
+_newmsys=${_newmsysbase}/msys64
 
 declare -a undo_commands
 
@@ -43,16 +38,12 @@ exit_cleanly() {
 do_seds() {
   find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" \) -exec sed -i "s|@DATE@|${_dateqif}|g" "{}" \;
   find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" \) -exec sed -i "s|@VERSION@|${_version}|g" "{}" \;
-  find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" -or -name "installscript.js" \) -exec sed -i "s|@BITNESS@|${_bitness}|g" "{}" \;
   undo_commands+=("undo_seds")
 }
 
 undo_seds() {
   find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" \) -exec sed -i "s|<ReleaseDate>${_dateqif}<|<ReleaseDate>@DATE@<|g" "{}" \;
   find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" \) -exec sed -i "s|<Version>${_version}<|<Version>@VERSION@<|g" "{}" \;
-  find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" -or -name "installscript.js" \) -exec sed -i "s|msys${_bitness}|msys@BITNESS@|g" "{}" \;
-  find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" -or -name "installscript.js" \) -exec sed -i "s|${_bitness}bit|@BITNESS@bit|g" "{}" \;
-  find "${_ifwroot}" \( -name "package.xml" -or -name "config.xml" -or -name "installscript.js" \) -exec sed -i "s|if (\"@BITNESS@bit\" === \"@BITNESS@bit\")|if (\"@BITNESS@bit\" === \"32bit\")|g" "{}" \;
 }
 
 create_archives() {
@@ -61,13 +52,13 @@ create_archives() {
   mkdir -p "${_data}"
 
   local _dirs="${_newmsys}/"*
-  local _compress_cmd="${_archivegen} --compression 9 ${_data}/msys${_bitness}.7z ${_dirs}"
+  local _compress_cmd="${_archivegen} --compression 9 ${_data}/msys64.7z ${_dirs}"
   pushd / > /dev/null
     echo "Run: ${_compress_cmd} ..." | tee -a ${_log}
     eval "${_compress_cmd}" 2>&1 | tee -a ${_log}
     _result=$?
     if [ "${_result}" -eq "0" ]; then
-          echo " archivegen succeeded. Created ${_data}/msys${_bitness}.7z" | tee -a ${_log}
+          echo " archivegen succeeded. Created ${_data}/msys64.7z" | tee -a ${_log}
     else
           exit_cleanly "3" "archivegen failed. See ${_log}"
     fi
@@ -75,7 +66,7 @@ create_archives() {
 
   pushd ${_newmsysbase} > /dev/null
     export XZ_OPT="-e9T0"
-    local _compress_cmd2="/usr/bin/tar --transform='s/:/_/g' --dereference --hard-dereference -cJf ${_thisdir}/${_filename2} msys${_bitness}"
+    local _compress_cmd2="/usr/bin/tar --transform='s/:/_/g' --dereference --hard-dereference -cJf ${_thisdir}/${_filename2} msys64"
     echo "Run: ${_compress_cmd2} ..." | tee -a ${_log}
     eval "${_compress_cmd2}" 2>&1 | tee -a ${_log}
     _result=$?
@@ -86,7 +77,7 @@ create_archives() {
     fi
 
     # self extracting cli 7z archive
-    "${_thisdir}/create-sfx.sh" "msys${_bitness}" "${_thisdir}/${_filename3}"
+    "${_thisdir}/create-sfx.sh" "msys64" "${_thisdir}/${_filename3}"
   popd > /dev/null
 }
 
@@ -123,7 +114,7 @@ create_chroot_system() {
 }
 
 if [ ! -f "${_archivegen}" ]; then
-  eval "pacman -S --noconfirm mingw${_bitness}/mingw-w64-${_arch}-qt-installer-framework" | tee -a ${_log}
+  eval "pacman -S --noconfirm mingw64/mingw-w64-${_arch}-qt-installer-framework" | tee -a ${_log}
 fi
 
 if [ ! -f "${_archivegen}" ]; then

--- a/qt-ifw/config/config.xml
+++ b/qt-ifw/config/config.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Installer>
-    <Name>MSYS2 @BITNESS@bit</Name>
+    <Name>MSYS2</Name>
     <Version>@VERSION@</Version>
-    <Title>MSYS2 @BITNESS@bit</Title>
+    <Title>MSYS2</Title>
     <Publisher>The MSYS2 Developers</Publisher>
     <ControlScript>control.js</ControlScript>
-    <StartMenuDir>MSYS2 @BITNESS@bit</StartMenuDir>
+    <StartMenuDir>MSYS2</StartMenuDir>
     <RunProgram>@TargetDir@/msys2_shell.cmd</RunProgram>
     <RunProgramArguments></RunProgramArguments>
     <InstallerApplicationIcon>../../msys2</InstallerApplicationIcon>

--- a/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
+++ b/qt-ifw/packages/com.msys2.root.base/meta/installscript.js
@@ -23,11 +23,6 @@ function createShortcuts()
     component.addOperation("CreateShortcut", "@TargetDir@/clang64.exe", "@StartMenuDir@/MSYS2 CLANG64.lnk", "iconPath=@TargetDir@/clang64.exe");
     component.addOperation("CreateShortcut", "@TargetDir@/msys2.exe", "@StartMenuDir@/MSYS2 MSYS.lnk", "iconPath=@TargetDir@/msys2.exe");
 
-    if ("@BITNESS@bit" === "32bit") {
-        component.addOperation( "Execute",
-                               ["@TargetDir@\\autorebase.bat"]);
-    }
-
     component.addOperation( "Execute",
                            ["@TargetDir@\\usr\\bin\\bash.exe", "--login", "-c", "exit"]);
 }

--- a/qt-ifw/packages/com.msys2.root.base/meta/package.xml
+++ b/qt-ifw/packages/com.msys2.root.base/meta/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Package>
-  <DisplayName>MSYS2 @BITNESS@bit base</DisplayName>
+  <DisplayName>MSYS2 base</DisplayName>
   <Description>Cygwin-derived Posix-like env. for Windows with Arch Linux's Pacman</Description>
   <Version>@VERSION@</Version>
   <ReleaseDate>@DATE@</ReleaseDate>

--- a/qt-ifw/packages/com.msys2.root/meta/installscript.js
+++ b/qt-ifw/packages/com.msys2.root/meta/installscript.js
@@ -4,7 +4,7 @@ function Component() {
     if (systemDrive === "") {
         systemDrive = "C:";
     }
-    var targetDir = installer.value("TargetDir", systemDrive+"\\msys@BITNESS@")
+    var targetDir = installer.value("TargetDir", systemDrive+"\\msys64")
 
     installer.setValue("TargetDir", targetDir);
     installer.setDefaultPageVisible(QInstaller.Introduction, false);

--- a/qt-ifw/packages/com.msys2.root/meta/package.xml
+++ b/qt-ifw/packages/com.msys2.root/meta/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <Package>
-  <DisplayName>MSYS2 @BITNESS@bit</DisplayName>
+  <DisplayName>MSYS2</DisplayName>
   <Description>Cygwin-derived Posix-like env. for Windows with Arch Linux's Pacman</Description>
   <Version>@VERSION@</Version>
   <ReleaseDate>@DATE@</ReleaseDate>


### PR DESCRIPTION
We haven't supported 32bit in a long time, so remove anything
referencing it.

Also remove the "64bit" tag from all names/titles/descriptions to avoid
implying that there is a different variant of the installer available.