### PR TITLE
Start a mingw64 shell at the end

### DIFF
--- a/qt-ifw/config/config.xml
+++ b/qt-ifw/config/config.xml
@@ -6,7 +6,7 @@
     <Publisher>The MSYS2 Developers</Publisher>
     <ControlScript>control.js</ControlScript>
     <StartMenuDir>MSYS2</StartMenuDir>
-    <RunProgram>@TargetDir@/msys2_shell.cmd</RunProgram>
+    <RunProgram>@TargetDir@/mingw64.exe</RunProgram>
     <RunProgramArguments></RunProgramArguments>
     <InstallerApplicationIcon>../../msys2</InstallerApplicationIcon>
     <InstallerWindowIcon>../../msys2</InstallerWindowIcon>


### PR DESCRIPTION
Many new users want to compile some C code with gcc for Windows,
so that's what we suggest as first steps on the download page.

At the end of the wizard there is a "Run MSYS2 now" checkbox which
would start a MSYS shell where mingw tools aren't in path.

Run a mingw64 shell instead, so users end up in the environment the
install guide suggests and don't have to search in the start menu
for it etc.