### PR TITLE
Check the Windows version and error out if it's not supported

### DIFF
--- a/qt-ifw/packages/com.msys2.root/meta/installscript.js
+++ b/qt-ifw/packages/com.msys2.root/meta/installscript.js
@@ -1,4 +1,37 @@
+function cancelInstaller(message)
+{
+    installer.setDefaultPageVisible(QInstaller.Introduction, false);
+    installer.setDefaultPageVisible(QInstaller.TargetDirectory, false);
+    installer.setDefaultPageVisible(QInstaller.ComponentSelection, false);
+    installer.setDefaultPageVisible(QInstaller.ReadyForInstallation, false);
+    installer.setDefaultPageVisible(QInstaller.StartMenuSelection, false);
+    installer.setDefaultPageVisible(QInstaller.PerformInstallation, false);
+    installer.setDefaultPageVisible(QInstaller.LicenseCheck, false);
+
+    var abortText = "<font color='red'>" + message +"</font>";
+    installer.setValue("FinishedText", abortText);
+    installer.setValue("RunProgram", null);
+}
+
+function isSupported()
+{
+    if (systemInfo.kernelType === "winnt") {
+        var major = parseInt(systemInfo.kernelVersion.split(".", 1));
+        var minor = parseInt(systemInfo.kernelVersion.split(".", 2)[1]);
+        if (major > 6 || (major == 6 && minor >= 1)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function Component() {
+
+    if (!isSupported()) {
+        cancelInstaller("Installation on " + systemInfo.prettyProductName + " is not supported");
+        return;
+    }
+
     var systemDrive = installer.environmentVariable("SystemDrive");
     // Use C: as a default for messed up systems.
     if (systemDrive === "") {


### PR DESCRIPTION
Currently it's Windows 7+. In the future we might bump it to 8.1 (so >= kernel 6.3) .

Fixes #55