### PR TITLE
Use WizardStyle=Modern instead of Aero

### DIFF
--- a/qt-ifw/config/config.xml
+++ b/qt-ifw/config/config.xml
@@ -11,6 +11,8 @@
     <InstallerApplicationIcon>msys2</InstallerApplicationIcon>
     <InstallerWindowIcon>msys2.ico</InstallerWindowIcon>
     <InstallActionColumnVisible>false</InstallActionColumnVisible>
+    <WizardStyle>Modern</WizardStyle>
+    <WizardDefaultWidth>40em</WizardDefaultWidth>
     <MaintenanceToolName>uninstall</MaintenanceToolName>
     <SupportsModify>false</SupportsModify>
     <RepositorySettingsPageVisible>false</RepositorySettingsPageVisible>


### PR DESCRIPTION
The later seems to be the default for some reason but does not support dark mode (or breaks when dark mode is enabled). Use the "Modern" style instead, and also set a smaller default width while at it.

Note that the style is a QWizard concept and not QTIFW specific.

The only related upstream issue I found was
https://bugreports.qt.io/browse/QTBUG-123853

Fixes #84